### PR TITLE
当图片url为空时return，使用img原有的src

### DIFF
--- a/src/vue.lazyimg.js
+++ b/src/vue.lazyimg.js
@@ -77,6 +77,9 @@ Vue.lazyimg ={
 
         //vue directive update
         function update(value){
+            if (!value) {
+                return;
+            }
             var isFadeIn = this.modifiers.fadein || options.fadein
             var isNoHori = this.modifiers.nohori || options.nohori
             if(isFadeIn){


### PR DESCRIPTION
npm上的版本落后了，就不提issues了。项目里用着呢，求更新npm啊…… T T
